### PR TITLE
fix: adjust loader height based on login state to prevent scrollbar

### DIFF
--- a/src/components/Loader/index.tsx
+++ b/src/components/Loader/index.tsx
@@ -1,10 +1,14 @@
 import Lottie from "lottie-react";
 import AutifyLoader from "../../assets/authifyLoader.json";
+import { useUserAuth } from "../../context/UserAuthContext";
 // interface ILoader{}
 
 const Loader: React.FunctionComponent = () => {
+    const {user} =useUserAuth();
   return (
-    <div className="min-h-[100dvh] flex items-center w-[300px] mx-auto">
+    <div className={`flex items-center w-[300px] mx-auto ${
+        user ? "h-[calc(100dvh-64px)]" : "h-[100dvh]"
+      }`}>
       <Lottie animationData={AutifyLoader} loop autoPlay />
     </div>
   );


### PR DESCRIPTION
- Adjusted the loader height dynamically based on the user authentication state.
- When the user is not logged in, loader takes full `100dvh`.
- When logged in, loader height becomes `calc(100dvh - 64px)` to account for the topbar height (64px).
- This prevents unwanted vertical scroll when the loader appears post-login.